### PR TITLE
Fix and document custom library path configuration

### DIFF
--- a/src/informationView.ts
+++ b/src/informationView.ts
@@ -4,15 +4,19 @@ type Element = {
   readonly identifier: string;
 };
 
-class InformationView {
-  constructor() {
+export class InformationView {
+  constructor(reload: () => Promise<void>) {
     this._treeView = new TreeView("apexskier.typescript.sidebar.info", {
       dataProvider: this,
     });
 
-    nova.commands.register("apexskier.typescript.refreshInformation", () => {
-      this.reload();
-    });
+    nova.commands.register(
+      "apexskier.typescript.refreshInformation",
+      async () => {
+        await reload();
+        this.reload();
+      }
+    );
 
     this.getChildren = this.getChildren.bind(this);
     this.getTreeItem = this.getTreeItem.bind(this);
@@ -58,5 +62,3 @@ class InformationView {
     return item;
   }
 }
-
-export const informationView = new InformationView();

--- a/test-workspaces/.nova/Configuration.json
+++ b/test-workspaces/.nova/Configuration.json
@@ -1,0 +1,3 @@
+{
+  "apexskier.typescript.config.tslibPath": "foo/node_modules/typescript/lib/"
+}

--- a/test-workspaces/README.md
+++ b/test-workspaces/README.md
@@ -1,0 +1,1 @@
+Opening Nova to this directory should result in TypeScript 3.6.5 from `foo` being used.

--- a/test-workspaces/bar/README.md
+++ b/test-workspaces/bar/README.md
@@ -1,0 +1,1 @@
+Opening Nova to this directory should result in TypeScript 3.2.4 being used.

--- a/test-workspaces/bar/package-lock.json
+++ b/test-workspaces/bar/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "typescript": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
+    }
+  }
+}

--- a/test-workspaces/baz/README.md
+++ b/test-workspaces/baz/README.md
@@ -1,0 +1,1 @@
+Opening Nova to this directory should result in the bundled TypeScript version being used.

--- a/test-workspaces/foo/README.md
+++ b/test-workspaces/foo/README.md
@@ -1,0 +1,1 @@
+Opening Nova to this directory should result in TypeScript 3.6.5 being used.

--- a/test-workspaces/foo/package-lock.json
+++ b/test-workspaces/foo/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "typescript": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
+      "integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ=="
+    }
+  }
+}

--- a/typescript.novaextension/README.md
+++ b/typescript.novaextension/README.md
@@ -16,7 +16,9 @@ From the menu, select Extensions > TypeScript.
 
 * Find Symbol
 
-### Screenshots
+### Usage
+
+#### Screenshots
 
 **Inline errors**
 
@@ -26,6 +28,20 @@ From the menu, select Extensions > TypeScript.
 
 ![Example type info](https://raw.githubusercontent.com/apexskier/nova-typescript/14378cc1fccc752cff1bceef2706f98915966a3b/typescript.novaextension/Images/README/example-typeinfo.png)
 
-**Find Symbol**
+#### Sidebar
+
+The sidebar shows status information about the extension including the version of typescript it's using and if it's started successfully.
+
+![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/3cbd2a83f37df63e3e249d16d741ebea82254640/typescript.novaextension/Images/README/example-findsymbol.png)
+
+#### Find Symbol
+
+Find symbol performs a project search for a symbol. Results are shown in the sidebar.
 
 ![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/fdf669355c7ffcec4a943ebc9de76b45738f08a7/typescript.novaextension/Images/README/example-findsymbol.png)
+
+#### Using the workspace version of TypeScript
+
+This extension will automatically find the workspace version of TypeScript installed under `node_modules` in your workspace root. If one isn't installed it will use a recent, bundled version of typescript.
+
+To customize this you can specify the TypeScript library location in workspace preferences (Extensions > TypeScript > Preferences > TypeScript Library) as an absolute or workspace-relative path. This should point to a directory containing the TypeScript `tsserver.js` file, generally ending with `node_modules/typescript/lib`. If installed globally, you can find the installation location using `npm list -g typescript` (e.g. "/usr/local/lib/node_modules/typescript/lib"). (You should only need this if your workspace doesn't install typescript under the workspace's root `node_modules` directory or you use a global installation of TypeScript)

--- a/typescript.novaextension/README.md
+++ b/typescript.novaextension/README.md
@@ -32,7 +32,7 @@ From the menu, select Extensions > TypeScript.
 
 The sidebar shows status information about the extension including the version of typescript it's using and if it's started successfully.
 
-![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/3cbd2a83f37df63e3e249d16d741ebea82254640/typescript.novaextension/Images/README/example-findsymbol.png)
+![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/3cbd2a83f37df63e3e249d16d741ebea82254640/typescript.novaextension/Images/README/example-sidebar.png)
 
 #### Find Symbol
 

--- a/typescript.novaextension/README.md
+++ b/typescript.novaextension/README.md
@@ -22,23 +22,23 @@ From the menu, select Extensions > TypeScript.
 
 **Inline errors**
 
-![Example errors](https://raw.githubusercontent.com/apexskier/nova-typescript/14378cc1fccc752cff1bceef2706f98915966a3b/typescript.novaextension/Images/README/example-error.png)
+<img src="https://raw.githubusercontent.com/apexskier/nova-typescript/14378cc1fccc752cff1bceef2706f98915966a3b/typescript.novaextension/Images/README/example-error.png" width="400" alt="Example errors">
 
 **Type info on hover**
 
-![Example type info](https://raw.githubusercontent.com/apexskier/nova-typescript/14378cc1fccc752cff1bceef2706f98915966a3b/typescript.novaextension/Images/README/example-typeinfo.png)
+<img src="https://raw.githubusercontent.com/apexskier/nova-typescript/14378cc1fccc752cff1bceef2706f98915966a3b/typescript.novaextension/Images/README/example-typeinfo.png" width="400" alt="Example type info">
 
 #### Sidebar
 
 The sidebar shows status information about the extension including the version of typescript it's using and if it's started successfully.
 
-![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/3cbd2a83f37df63e3e249d16d741ebea82254640/typescript.novaextension/Images/README/example-sidebar.png)
+<img src="https://raw.githubusercontent.com/apexskier/nova-typescript/3cbd2a83f37df63e3e249d16d741ebea82254640/typescript.novaextension/Images/README/example-sidebar.png" width="400" alt="Sidebar information">
 
 #### Find Symbol
 
 Find symbol performs a project search for a symbol. Results are shown in the sidebar.
 
-![Find symbol sidebar](https://raw.githubusercontent.com/apexskier/nova-typescript/fdf669355c7ffcec4a943ebc9de76b45738f08a7/typescript.novaextension/Images/README/example-findsymbol.png)
+<img src="https://raw.githubusercontent.com/apexskier/nova-typescript/fdf669355c7ffcec4a943ebc9de76b45738f08a7/typescript.novaextension/Images/README/example-findsymbol.png" width="400" alt="Find symbol sidebar">
 
 #### Using the workspace version of TypeScript
 

--- a/typescript.novaextension/extension.json
+++ b/typescript.novaextension/extension.json
@@ -26,8 +26,9 @@
     {
       "key": "apexskier.typescript.config.tslibPath",
       "title": "TypeScript Library",
-      "description": "Path to your locally installed TypeScript library, generally in node_modules/typescript/lib.",
-      "type": "path"
+      "description": "(optional) Path to a custom installed TypeScript library directory. See \"Using the workspace version of TypeScript\" in the README for details.",
+      "link": "nova://extension/?id=apexskier.typescript",
+      "type": "string"
     }
   ],
 


### PR DESCRIPTION
- Make "refresh" sidebar button restart language server
- Fix reading `tslibPath` configuration
- Change `tslibPath` configuration to type string (path doesn't support directories)
- Auto-refresh when `tslibPath` configuration changes
- Support workspace-relative `tslibPath` paths
- Improve documentation

Resolves #11